### PR TITLE
PR automation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @justeattakeaway/aws-watchman

--- a/.github/workflows/approve-and-merge.yml
+++ b/.github/workflows/approve-and-merge.yml
@@ -1,0 +1,160 @@
+name: approve-and-merge
+
+on:
+  pull_request:
+    branches: [ main ]
+
+env:
+  REVIEWER_LOGIN: ${{ vars.REVIEWER_USER_NAME }}
+
+permissions:
+  contents: read
+
+jobs:
+  review-pull-request:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == vars.UPDATER_COMMIT_USER_NAME }}
+
+    steps:
+
+    - name: Generate GitHub application token
+      id: generate-application-token
+      uses: peter-murray/workflow-application-token-action@8e1ba3bf1619726336414f1014e37f17fbadf1db # v2.1.0
+      with:
+        application_id: ${{ secrets.REVIEWER_APPLICATION_ID }}
+        application_private_key: ${{ secrets.REVIEWER_APPLICATION_PRIVATE_KEY }}
+        permissions: "contents:write, pull_requests:write"
+
+    - name: Install powershell-yaml
+      shell: pwsh
+      run: Install-Module -Name powershell-yaml -Force -MaximumVersion "0.4.7"
+
+    - name: Check which dependencies were updated
+      id: check-dependencies
+      env:
+        # This list of trusted package prefixes needs to stay in sync with include-nuget-packages in the update-dotnet-sdk workflow.
+        INCLUDE_NUGET_PACKAGES: ""
+        GH_TOKEN: ${{ steps.generate-application-token.outputs.token }}
+      shell: pwsh
+      run: |
+        # Replicate the logic in the dependabot/fetch-metadata action.
+        # See https://github.com/dependabot/fetch-metadata/blob/aea2135c95039f05c64436f1d14638c300e10b2b/src/dependabot/update_metadata.ts#L29-L68.
+        # Query the GitHub API to get the commits in the pull request.
+        $commits = gh api `
+          /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits `
+          --jq '.[] | { author: .author.login, message: .commit.message }' | ConvertFrom-Json
+
+        # We should only approve pull requests that only contain commits from
+        # the GitHub user we expected and only commits that contain the metadata
+        # we need to determine what dependencies were updated by the other workflow.
+        $expectedUser = "${{ vars.UPDATER_COMMIT_USER_NAME }}"
+        $onlyDependencyUpdates = $True
+        $onlyChangesFromUser = $True
+
+        $dependencies = @()
+
+        foreach ($commit in $commits) {
+          if ($commit.Author -ne $expectedUser) {
+            # Some other commit is in the pull request
+            $onlyChangesFromUser = $False
+          }
+          # Extract the YAML metadata block from the commit message.
+          $match = [Regex]::Match($commit.Message, '(?m)^-{3}\s(?<dependencies>[\S|\s]*?)\s^\.{3}$')
+          if ($match.Success -eq $True) {
+            # Extract the names and update type from each dependency.
+            $metadata = ($match.Value | ConvertFrom-Yaml -Ordered)
+            $updates = $metadata["updated-dependencies"]
+            if ($updates) {
+              foreach ($update in $updates) {
+                $dependencies += @{
+                  Name = $update['dependency-name'];
+                  Type = $update['update-type'];
+                }
+              }
+            }
+          }
+          else {
+            # The pull request contains a commit that we didn't expect as the metadata is missing.
+            $onlyDependencyUpdates = $False
+          }
+        }
+
+        # Did we find at least one dependency?
+        $isPatch = $dependencies.Length -gt 0
+        $onlyTrusted = $dependencies.Length -gt 0
+        $trustedPackages = $env:INCLUDE_NUGET_PACKAGES.Split(',')
+
+        foreach ($dependency in $dependencies) {
+          $isPatch = $isPatch -And $dependency.Type -eq "version-update:semver-patch"
+          $onlyTrusted = $onlyTrusted -And
+            (
+              ($dependency.Name -eq "Microsoft.NET.Sdk") -Or
+              (($trustedPackages | Where-Object { $dependency.Name.StartsWith($_) }).Count -gt 0)
+            )
+        }
+
+        # We only trust the pull request to approve and auto-merge it
+        # if it only contains commits which change the .NET SDK and
+        # Microsoft-published NuGet packages that were made by the GitHub
+        # login we expect to make those changes in the other workflow.
+        $isTrusted = (($onlyTrusted -And $isPatch) -And $onlyChangesFromUser) -And $onlyDependencyUpdates
+        "is-trusted-update=$isTrusted" >> $env:GITHUB_OUTPUT
+
+    - name: Checkout code
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      # As long as it's not already approved, approve the pull request and enable auto-merge.
+      # Our CI tests coupled with required statuses should ensure that the changes compile
+      # and that the application is still functional after the update; any bug that might be
+      # introduced by the update should be caught by the tests. If that happens, the build
+      # workflow will fail and the preconditions for the auto-merge to happen won't be met.
+    - name: Approve pull request and enable auto-merge
+      if: ${{ steps.check-dependencies.outputs.is-trusted-update == 'true' }}
+      env:
+        GH_TOKEN: ${{ steps.generate-application-token.outputs.token }}
+        PR_URL: ${{ github.event.pull_request.html_url }}
+      shell: pwsh
+      run: |
+        $approvals = gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews | ConvertFrom-Json
+        $approvals = $approvals | Where-Object { $_.user.login -eq $env:REVIEWER_LOGIN }
+        $approvals = $approvals | Where-Object { $_.state -eq "APPROVED" }
+
+        if ($approvals.Length -eq 0) {
+          gh pr checkout "$env:PR_URL"
+          gh pr review --approve "$env:PR_URL"
+          gh pr merge --auto --squash "$env:PR_URL"
+        }
+        else {
+          Write-Host "PR already approved.";
+        }
+
+    # If something was present in the pull request that isn't expected, then disable
+    # auto-merge so that a human is required to look at the pull request and make a
+    # decision to merge it or not. This is to prevent the pull request from being merged
+    # automatically if there's an unexpected change introduced. Any existing review
+    # approvals that were made by the bot are also dismissed so human approval is required.
+    - name: Disable auto-merge and dismiss approvals
+      if: ${{ steps.check-dependencies.outputs.is-trusted-update != 'true' }}
+      env:
+        GH_TOKEN: ${{ steps.generate-application-token.outputs.token }}
+        PR_URL: ${{ github.event.pull_request.html_url }}
+      shell: pwsh
+      run: |
+        $approvals = gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews | ConvertFrom-Json
+        $approvals = $approvals | Where-Object { $_.user.login -eq $env:REVIEWER_LOGIN }
+        $approvals = $approvals | Where-Object { $_.state -eq "APPROVED" }
+
+        if ($approvals.Length -gt 0) {
+          gh pr checkout "$env:PR_URL"
+          gh pr merge --disable-auto "$env:PR_URL"
+          foreach ($approval in $approvals) {
+            gh api `
+              --method PUT `
+              /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/$($approval.id)/dismissals `
+              -f message='Cannot approve as other changes have been introduced.' `
+              -f event='DISMISS'
+          }
+        }
+        else {
+          Write-Host "PR not already approved.";
+        }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
 
     - name: Build, Test and Publish
       shell: pwsh
@@ -37,7 +37,7 @@ jobs:
         TERM: xterm
 
     - name: Publish artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: artifacts-${{ matrix.os }}
         path: ./artifacts/publish

--- a/.github/workflows/dependabot-approve.yml
+++ b/.github/workflows/dependabot-approve.yml
@@ -1,0 +1,45 @@
+name: dependabot-approve
+
+on: pull_request_target
+
+permissions:
+  contents: read
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+
+    steps:
+
+      - name: Get dependabot metadata
+        uses: dependabot/fetch-metadata@efb5c8deb113433243b6b08de1aa879d5aa01cf7 # v1.4.0
+        id: dependabot-metadata
+
+      - name: Generate GitHub application token
+        id: generate-application-token
+        uses: peter-murray/workflow-application-token-action@8e1ba3bf1619726336414f1014e37f17fbadf1db # v2.1.0
+        with:
+          application_id: ${{ secrets.REVIEWER_APPLICATION_ID }}
+          application_private_key: ${{ secrets.REVIEWER_APPLICATION_PRIVATE_KEY }}
+          permissions: "contents:write, pull_requests:write"
+
+      - name: Checkout code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: Approve pull request and enable auto-merge
+        shell: bash
+        if: |
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/checkout') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/dependency-review-action') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/setup-dotnet') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/upload-artifact') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'dependabot/fetch-metadata')
+        env:
+          GH_TOKEN: ${{ steps.generate-application-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr checkout "$PR_URL"
+          if [ "$(gh pr status --json reviewDecision -q .currentBranch.reviewDecision)" != "APPROVED" ];
+          then gh pr review --approve "$PR_URL" && gh pr merge --auto --squash "$PR_URL"
+          fi

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+name: dependency-review
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: Review dependencies
+        uses: actions/dependency-review-action@f46c48ed6d4f1227fb2d9ea62bf6bcbed315589e # v3.0.4

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -1,33 +1,20 @@
 name: update-dotnet-sdk
 
-env:
-  GIT_COMMIT_USER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
-  GIT_COMMIT_USER_NAME: github-actions[bot]
-  TERM: xterm
-
 on:
   schedule:
     - cron:  '00 19 * * TUE'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
-  update-dotnet-sdk:
-    name: Update .NET SDK
-    runs-on: ubuntu-latest
-    if: ${{ github.event.repository.fork == false }}
-
-    steps:
-
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Update .NET SDK
-      id: update-dotnet-sdk
-      uses: martincostello/update-dotnet-sdk@v2
-      with:
-        labels: "dependencies,.NET"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        user-email: ${{ env.GIT_COMMIT_USER_EMAIL }}
-        user-name: ${{ env.GIT_COMMIT_USER_NAME }}
+  update-sdk:
+    uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@6cfd047b0c2ce72ea0e22708bc1918a3d912c050 # v2.2.0
+    with:
+      labels: "dependencies,.NET"
+      update-nuget-packages: false
+      user-email: ${{ vars.UPDATER_COMMIT_USER_EMAIL }}
+      user-name: ${{ vars.UPDATER_COMMIT_USER_NAME }}
+    secrets:
+      application-id: ${{ secrets.UPDATER_APPLICATION_ID }}
+      application-private-key: ${{ secrets.UPDATER_APPLICATION_PRIVATE_KEY }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
     <NoWarn Condition=" '$(GenerateDocumentationFile)' != 'true' ">$(NoWarn);SA0001</NoWarn>
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/justeat/AwsWatchman</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/justeattakeaway/AwsWatchman</PackageProjectUrl>
     <PackageReleaseNotes>See $(PackageProjectUrl)/releases for details.</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>alerting,aws,monitoring</PackageTags>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,6 +27,7 @@
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/justeattakeaway/AwsWatchman</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>See $(PackageProjectUrl)/releases for details.</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>alerting,aws,monitoring</PackageTags>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Because unmonitored infrastructure will bite you
 
-[![Build status](https://github.com/justeat/AwsWatchman/workflows/build/badge.svg?branch=main&event=push)](https://github.com/justeat/AwsWatchman/actions?query=workflow%3Abuild+branch%3Amain+event%3Apush)
+[![Build status](https://github.com/justeattakeaway/AwsWatchman/workflows/build/badge.svg?branch=main&event=push)](https://github.com/justeattakeaway/AwsWatchman/actions?query=workflow%3Abuild+branch%3Amain+event%3Apush)
 
 ## What
 


### PR DESCRIPTION
- Add code owners for the repo.
- Update the organisation from `justeat` to `justeattakeaway`.
- Use the new reusable workflow to handle .NET SDK updates.
- Authenticate as GitHub app instead of using `GITHUB_TOKEN`.
- Add a workflow to automatically approve and merge .NET SDK updates.
- Add a workflow to automatically approve and merge dependabot updates for GitHub-authored actions.
- Pin the actions for the build by their SHA.
- Add package readme.
