### PR TITLE
Revert "Bump Moq from 4.18.4 to 4.20.0"

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageVersion Include="Moq" Version="4.20.0" />
+    <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="StructureMap" Version="4.7.1" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
   </ItemGroup>


### PR DESCRIPTION
Reverts justeattakeaway/AwsWatchman#364 to stick to a version without privacy concerns.