### PR TITLE
Fix build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Because unmonitored infrastructure will bite you
 
-[![Build status](https://github.com/justeattakeaway/AwsWatchman/workflows/build/badge.svg?branch=main&event=push)](https://github.com/justeattakeaway/AwsWatchman/actions?query=workflow%3Abuild+branch%3Amain+event%3Apush)
+[![Build status](https://github.com/justeattakeaway/AwsWatchman/actions/workflows/build.yml/badge.svg?branch=main&event=push)](https://github.com/justeattakeaway/AwsWatchman/actions/workflows/build.yml?query=branch%3Amain+event%3Apush)
 
 | **Package** | **Latest Version** |
 | :---------- | :----------------- |


### PR DESCRIPTION
Fix-up the build badge as the old URL seems to have stopped working.
